### PR TITLE
Added gotoDeclarationHandler statements to goto statements

### DIFF
--- a/src/com/perl5/lang/perl/psi/PerlGotoLabelElement.java
+++ b/src/com/perl5/lang/perl/psi/PerlGotoLabelElement.java
@@ -1,0 +1,12 @@
+package com.perl5.lang.perl.psi;
+
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by pverma on 12/30/15.
+ */
+public interface PerlGotoLabelElement extends PsiElement {
+    @NotNull
+    String getLabel();
+}

--- a/src/com/perl5/lang/perl/psi/PerlVisitor.java
+++ b/src/com/perl5/lang/perl/psi/PerlVisitor.java
@@ -37,6 +37,11 @@ public class PerlVisitor extends PsiPerlVisitor
 		visitPsiElement(o);
 	}
 
+	public void visitGotoLabelElement(@NotNull PerlGotoLabelElement o)
+	{
+		visitPsiElement(o);
+	}
+
 	public void visitSubNameElement(@NotNull PerlSubNameElement o)
 	{
 		visitPsiElement(o);

--- a/src/com/perl5/lang/perl/psi/impl/PerlGotoLabelElementImpl.java
+++ b/src/com/perl5/lang/perl/psi/impl/PerlGotoLabelElementImpl.java
@@ -1,0 +1,71 @@
+package com.perl5.lang.perl.psi.impl;
+
+import com.intellij.openapi.util.AtomicNotNullLazyValue;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.tree.IElementType;
+import com.perl5.lang.perl.psi.PerlGlobVariable;
+import com.perl5.lang.perl.psi.PerlGotoLabelElement;
+import com.perl5.lang.perl.psi.PerlVisitor;
+import com.perl5.lang.perl.psi.references.PerlGotoLabelReference;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by pverma on 12/30/15.
+ */
+public class PerlGotoLabelElementImpl extends LeafPsiElement implements PerlGotoLabelElement {
+
+    protected AtomicNotNullLazyValue<PsiReference[]> myReferences;
+
+    public PerlGotoLabelElementImpl(@NotNull IElementType type, CharSequence text) {
+        super(type, text);
+        createMyReferences();
+    }
+
+    private void createMyReferences()
+    {
+        myReferences = new AtomicNotNullLazyValue<PsiReference[]>()
+        {
+            @NotNull
+            @Override
+            protected PsiReference[] compute()
+            {
+                return new PsiReference[]{new PerlGotoLabelReference(PerlGotoLabelElementImpl.this, null)};
+            }
+        };
+    }
+
+    @NotNull
+    @Override
+    public String getLabel() {
+        return this.getText();
+    }
+
+    @Override
+    public void accept(@NotNull PsiElementVisitor visitor)
+    {
+        if (visitor instanceof PerlVisitor) ((PerlVisitor) visitor).visitGotoLabelElement(this);
+        else super.accept(visitor);
+    }
+
+    @NotNull
+    @Override
+    public PsiReference[] getReferences()
+    {
+        return myReferences.getValue();
+    }
+
+    @Override
+    public PsiReference getReference()
+    {
+        return myReferences.getValue()[0];
+    }
+
+    @Override
+    public void clearCaches()
+    {
+        super.clearCaches();
+        createMyReferences();
+    }
+}

--- a/src/com/perl5/lang/perl/psi/references/PerlGotoLabelReference.java
+++ b/src/com/perl5/lang/perl/psi/references/PerlGotoLabelReference.java
@@ -1,0 +1,38 @@
+package com.perl5.lang.perl.psi.references;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiReferenceBase;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
+import com.perl5.lang.perl.psi.PerlGotoLabelElement;
+import com.perl5.lang.perl.psi.utils.PerlPsiUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Created by pverma on 12/30/15.
+ */
+public class PerlGotoLabelReference extends PerlReference {
+
+    private static final ResolveCache.Resolver RESOLVER = new ResolveCache.Resolver()
+    {
+        @Override
+        public PsiElement resolve(@NotNull PsiReference psiReference, boolean incompleteCode)
+        {
+            PsiElement element = psiReference.getElement();
+            return PerlPsiUtil.findGotoLabelDeclaration(element.getContainingFile(), ((PerlGotoLabelElement) element).getLabel());
+        }
+    };
+
+    public PerlGotoLabelReference(@NotNull PsiElement element, TextRange textRange) {
+        super(element, textRange);
+    }
+
+    @Nullable
+    @Override
+    public PsiElement resolve() {
+        return ResolveCache.getInstance(myElement.getProject()).resolveWithCaching(this, RESOLVER, true, false);
+    }
+}
+

--- a/src/com/perl5/lang/perl/psi/utils/PerlASTFactory.java
+++ b/src/com/perl5/lang/perl/psi/utils/PerlASTFactory.java
@@ -49,6 +49,8 @@ public class PerlASTFactory extends DefaultASTFactoryImpl implements PerlElement
 			return new PerlNamespaceElementImpl(type, text);
 		else if (type == VERSION_ELEMENT)
 			return new PerlVersionElementImpl(type, text);
+		else if (type == LABEL)
+			return new PerlGotoLabelElementImpl(type, text);
 		else if (type == POD)
 			return super.createComment(type, text);
 		else

--- a/src/com/perl5/lang/perl/psi/utils/PerlPsiUtil.java
+++ b/src/com/perl5/lang/perl/psi/utils/PerlPsiUtil.java
@@ -21,10 +21,7 @@ import com.intellij.psi.*;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
-import com.perl5.lang.perl.psi.PerlHeredocOpener;
-import com.perl5.lang.perl.psi.PerlNamespaceElement;
-import com.perl5.lang.perl.psi.PerlStringContentElement;
-import com.perl5.lang.perl.psi.PsiPerlStatement;
+import com.perl5.lang.perl.psi.*;
 import com.perl5.lang.perl.psi.impl.PerlHeredocElementImpl;
 import com.perl5.lang.perl.psi.references.PerlHeredocReference;
 import org.jetbrains.annotations.NotNull;
@@ -237,5 +234,18 @@ public class PerlPsiUtil
 			result = result.getPrevSibling();
 		}
 		return result;
+	}
+
+	@Nullable
+	public static PsiElement findGotoLabelDeclaration(PsiFile containingFile, String text) {
+		Collection<PerlGotoLabelElement> gotoLabel = PsiTreeUtil.findChildrenOfType(containingFile, PerlGotoLabelElement.class);
+		for (PerlGotoLabelElement element : gotoLabel) {
+			if (element.textMatches(text)) {
+				if (element.getPrevSibling() == null) {
+					return element;
+				}
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
```
goto LABEL;
....
...
LABEL:
...
```
The feature to "Goto Declaration" in Intellij did not navigate to the declaration of the goto-label.
The patch visits (moves) the cursor to the declaration of the goto label.